### PR TITLE
Harden external-PR workflows and restrict command triggers

### DIFF
--- a/.github/workflows/e2e-external-phase-1.yml
+++ b/.github/workflows/e2e-external-phase-1.yml
@@ -12,7 +12,6 @@ jobs:
       github.event.pull_request.author_association != 'MEMBER'
       && (
         contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
-        || contains(fromJson('["kieferro", "ewjoachim"]'), github.event.review.user.login)
       )
       && github.event.review.state == 'approved'
       && contains(github.event.review.body, '/e2e')

--- a/.github/workflows/e2e-external-phase-1.yml
+++ b/.github/workflows/e2e-external-phase-1.yml
@@ -10,7 +10,10 @@ jobs:
     # If reviewed by a repo(/org) owner
     if: |
       github.event.pull_request.author_association != 'MEMBER'
-      && github.event.review.author_association == 'MEMBER'
+      && (
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+        || contains(fromJson('["kieferro", "ewjoachim"]'), github.event.review.user.login)
+      )
       && github.event.review.state == 'approved'
       && contains(github.event.review.body, '/e2e')
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-external-phase-1.yml
+++ b/.github/workflows/e2e-external-phase-1.yml
@@ -11,7 +11,7 @@ jobs:
     if: |
       github.event.pull_request.author_association != 'MEMBER'
       && (
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+        contains(fromJson('["OWNER", "MEMBER"]'), github.event.review.author_association)
       )
       && github.event.review.state == 'approved'
       && contains(github.event.review.body, '/e2e')

--- a/.github/workflows/e2e-external-phase-2.yml
+++ b/.github/workflows/e2e-external-phase-2.yml
@@ -83,10 +83,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          # Important: use the commit that was reviewed. GitHub is making sure
-          # that this is race-condition-proof
-          ref: ${{ steps.extract_commit.outputs.COMMIT_ID }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1

--- a/.github/workflows/e2e-private-link-in-pr.yml
+++ b/.github/workflows/e2e-private-link-in-pr.yml
@@ -10,6 +10,10 @@ jobs:
     if: |
       github.event.issue.pull_request
       && contains(github.event.comment.body, '/invite')
+      && (
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        || contains(fromJson('["kieferro", "ewjoachim"]'), github.event.comment.user.login)
+      )
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -42,6 +46,10 @@ jobs:
     if: |
       github.event.issue.pull_request
       && contains(github.event.comment.body, '/invite')
+      && (
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        || contains(fromJson('["kieferro", "ewjoachim"]'), github.event.comment.user.login)
+      )
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/e2e-private-link-in-pr.yml
+++ b/.github/workflows/e2e-private-link-in-pr.yml
@@ -11,8 +11,7 @@ jobs:
       github.event.issue.pull_request
       && contains(github.event.comment.body, '/invite')
       && (
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-        || contains(fromJson('["kieferro", "ewjoachim"]'), github.event.comment.user.login)
+        contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/e2e-private-link-in-pr.yml
+++ b/.github/workflows/e2e-private-link-in-pr.yml
@@ -46,8 +46,7 @@ jobs:
       github.event.issue.pull_request
       && contains(github.event.comment.body, '/invite')
       && (
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-        || contains(fromJson('["kieferro", "ewjoachim"]'), github.event.comment.user.login)
+        contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- stop checking out untrusted approved PR commits in `.github/workflows/e2e-external-phase-2.yml` before running secret-bearing test steps
- keep testing target selection via `COVERAGE_COMMENT_E2E_ACTION_REF`, but execute the harness from trusted workflow code
- require `/e2e` and `/invite` triggers to come from repo maintainers (`OWNER`/`MEMBER`)

## Security impact
This prevents exfiltration of long-lived e2e tokens from untrusted PR code execution and blocks arbitrary commenters from triggering secret-backed invite actions.

## Validation
- YAML parse validation for updated workflow files (`Psych.safe_load`)
